### PR TITLE
Add support for Casbin v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ JSON Adapter is the [JSON (JavaScript Object Notation)](https://www.json.org/) a
 package main
 
 import (
-	"github.com/casbin/casbin"
-	"github.com/casbin/json-adapter"
+	"github.com/casbin/casbin/v2"
+	"github.com/casbin/json-adapter/v2"
 )
 
 func main() {
 	// Initialize a JSON adapter and use it in a Casbin enforcer:
 	b := []byte{} // b stores Casbin policy in JSON bytes.
 	a := jsonadapter.NewAdapter(&b) // Use b as the data source. 
-	e := casbin.NewEnforcer("examples/rbac_model.conf", a)
+	e, _ := casbin.NewEnforcer("examples/rbac_model.conf", a)
 	
 	// Load the policy from JSON bytes b.
 	e.LoadPolicy()

--- a/adapter.go
+++ b/adapter.go
@@ -18,8 +18,8 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/casbin/casbin/model"
-	"github.com/casbin/casbin/persist"
+	"github.com/casbin/casbin/v2/model"
+	"github.com/casbin/casbin/v2/persist"
 )
 
 type CasbinRule struct {

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -18,8 +18,8 @@ import (
 	"log"
 	"testing"
 
-	"github.com/casbin/casbin"
-	"github.com/casbin/casbin/util"
+	"github.com/casbin/casbin/v2"
+	"github.com/casbin/casbin/v2/util"
 )
 
 func testGetPolicy(t *testing.T, e *casbin.Enforcer, res [][]string) {
@@ -34,7 +34,7 @@ func testGetPolicy(t *testing.T, e *casbin.Enforcer, res [][]string) {
 func TestAdapter(t *testing.T) {
 	// Because the JSON Buffer is empty at first,
 	// so we need to load the policy from the file adapter (.CSV) first.
-	e := casbin.NewEnforcer("examples/rbac_model.conf", "examples/rbac_policy.csv")
+	e, _ := casbin.NewEnforcer("examples/rbac_model.conf", "examples/rbac_policy.csv")
 
 	b := []byte{}
 	a := NewAdapter(&b)
@@ -58,6 +58,6 @@ func TestAdapter(t *testing.T) {
 	// Create an adapter and an enforcer.
 	// NewEnforcer() will load the policy automatically.
 	a = NewAdapter(&b)
-	e = casbin.NewEnforcer("examples/rbac_model.conf", a)
+	e, _ = casbin.NewEnforcer("examples/rbac_model.conf", a)
 	testGetPolicy(t, e, [][]string{{"alice", "data1", "read"}, {"bob", "data2", "write"}, {"data2_admin", "data2", "read"}, {"data2_admin", "data2", "write"}})
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/casbin/json-adapter/v2
+
+go 1.12
+
+require github.com/casbin/casbin/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible h1:1G1pk05UrOh0NlF1oeaaix1x8XzrfjIDK47TY0Zehcw=
+github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
+github.com/casbin/casbin/v2 v2.0.0 h1:OIcnP8SxwF1gmGxOn7Kod/O/7yJikpHWQz0qiBJpG/U=
+github.com/casbin/casbin/v2 v2.0.0/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=


### PR DESCRIPTION
start using go modules and mark this version as v2 to indicate
casbin v2 compatibility.